### PR TITLE
23-Replace-LibC-calls-in-Pharo-launcher-cli-with-PhLProcessWrapper

### DIFF
--- a/src/PharoLauncher-80Compatibility/ClapContext.extension.st
+++ b/src/PharoLauncher-80Compatibility/ClapContext.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #ClapContext }
+
+{ #category : #'*PharoLauncher-80Compatibility' }
+ClapContext class >> pragmaCommands [
+	^ (PragmaCollector filter: [:prg | prg selector = #commandline]) reset
+		collect: [ :pragma |
+			| theClass theSelector |
+			theClass := pragma method methodClass.
+			theSelector := pragma method selector.
+			self assert: [ theSelector isUnary ].
+			
+			theClass instanceSide
+				perform: theSelector ]
+]

--- a/src/PharoLauncher-CLI-Tests/PhLCliCommandTest.class.st
+++ b/src/PharoLauncher-CLI-Tests/PhLCliCommandTest.class.st
@@ -40,8 +40,16 @@ PhLCliCommandTest >> runCommand: args [
 
 { #category : #test }
 PhLCliCommandTest >> testExecuteOSShellCommand [
+
+	"nothing is executed"
+	self assert: PhLCliCommand new executeOSShellCommand isEmptyOrNil.
+	
+]
+
+{ #category : #test }
+PhLCliCommandTest >> testExecuteOSShellCommandWithArgs [
 	|aCmd|
 	aCmd := PhLCliCommand new. 
-	self deny: (aCmd executeOSShellCommand: 'ls') isEmptyOrNil.
-	self should: [aCmd executeOSShellCommand: 'bleh' ] raise: PhLProcessCommandError description: 'Invoking invalid OS shell command should end up with domain error exception: PHLProcessCommandError'.
+	self deny: (aCmd executeOSShellCommandWithArgs: #('ls')) isEmptyOrNil.
+	self should: [aCmd executeOSShellCommandWithArgs: #('bleh')] raise: PhLProcessCommandError description: 'Invoking invalid OS shell command should end up with domain error exception: PHLProcessCommandError'.
 ]

--- a/src/PharoLauncher-CLI-Tests/PhLCliCommandTest.class.st
+++ b/src/PharoLauncher-CLI-Tests/PhLCliCommandTest.class.st
@@ -37,3 +37,11 @@ PhLCliCommandTest >> outputString [
 PhLCliCommandTest >> runCommand: args [
 	^ (context arguments: args) execute.
 ]
+
+{ #category : #test }
+PhLCliCommandTest >> testExecuteOSShellCommand [
+	|aCmd|
+	aCmd := PhLCliCommand new. 
+	self deny: (aCmd executeOSShellCommand: 'ls') isEmptyOrNil.
+	self should: [aCmd executeOSShellCommand: 'bleh' ] raise: PhLProcessCommandError description: 'Invoking invalid OS shell command should end up with domain error exception: PHLProcessCommandError'.
+]

--- a/src/PharoLauncher-CLI-Tests/PhLImageCopyCliCommandTest.class.st
+++ b/src/PharoLauncher-CLI-Tests/PhLImageCopyCliCommandTest.class.st
@@ -5,13 +5,24 @@ Class {
 }
 
 { #category : #tests }
+PhLImageCopyCliCommandTest >> testCopyImageNoArguments [
+	self addImageNamed: 'myImage1'.
+	self addImageNamed: 'myImage2'.
+
+	self runCommand: #( 'launcher' 'image' 'copy').
+	 
+	self assert: (self errorString includesSubstring:'Image to copy argument is missing.').  
+	self assert: self imageRepository imagesName equals: #('myImage2' 'myImage1') asSet. 
+]
+
+{ #category : #tests }
 PhLImageCopyCliCommandTest >> testCopyImageNotEnoughArguments [
 	self addImageNamed: 'myImage1'.
 	self addImageNamed: 'myImage2'.
 
 	self runCommand: #( 'launcher' 'image' 'copy' 'myImage1' ).
 	 
-	self assert: (self errorString includesSubstring:'An argument is missing').  
+	self assert: (self errorString includesSubstring:'New image name argument is missing.').  
 	self assert: self imageRepository imagesName equals: #('myImage2' 'myImage1') asSet. 
 ]
 
@@ -44,6 +55,6 @@ PhLImageCopyCliCommandTest >> testCopyImageWrongName [
 
 	self runCommand: #('launcher' 'image' 'copy' 'myge1' 'myImage3' ).
 	 
-	self assert: (self errorString includesSubstring: 'please enter a correct local image').  
+	self assert: (self errorString includesSubstring: 'Please enter a correct local image').  
 	self assert: self imageRepository imagesName equals: #('myImage2' 'myImage1' ) asSet. 
 ]

--- a/src/PharoLauncher-CLI-Tests/PhLImageDeleteCliCommandTest.class.st
+++ b/src/PharoLauncher-CLI-Tests/PhLImageDeleteCliCommandTest.class.st
@@ -16,7 +16,7 @@ PhLImageDeleteCliCommandTest >> testDeleteImageNameWithPathShouldRaiseError [
 	self
 		assert:
 			(self errorString
-				includesSubstring: 'please enter a correct local image').
+				includesSubstring: 'Please enter a correct local image').
 	self assert: imagePath isFile.
 ]
 
@@ -27,7 +27,7 @@ PhLImageDeleteCliCommandTest >> testDeleteImageNameWithoutImageNameShouldRaiseEr
 	
 	self runCommand: #('launcher' 'image' 'delete').
  
-	self assert: ( self errorString includesSubstring: 'please enter a correct local image').  
+	self assert: ( self errorString includesSubstring: 'Please enter a correct local image').  
 ]
 
 { #category : #tests }
@@ -48,5 +48,5 @@ PhLImageDeleteCliCommandTest >> testDeleteImageWrongImageNameShouldRaiseError [
 	
 	self runCommand: #('launcher' 'image' 'delete' 'wrongImageName').
 	  
-	self assert: (self errorString includesSubstring: 'please enter a correct local image').  
+	self assert: (self errorString includesSubstring: 'Please enter a correct local image').  
 ]

--- a/src/PharoLauncher-CLI-Tests/PhLImageInfoCliCommandTest.class.st
+++ b/src/PharoLauncher-CLI-Tests/PhLImageInfoCliCommandTest.class.st
@@ -20,6 +20,6 @@ PhLImageInfoCliCommandTest >> testImageInfoWrongImageNameShouldRaiseError [
 	self addImageNamed: 'myImage2'.
 	
 	self runCommand: #('launcher' 'image' 'info' 'myImage3').
-	
-	self assert: (self errorString includesSubstring:'please enter a correct local image').
+
+	self assert: (self errorString includesSubstring:'Please enter a correct local image.').
 ]

--- a/src/PharoLauncher-CLI-Tests/PhLImageKillCliCommandTest.class.st
+++ b/src/PharoLauncher-CLI-Tests/PhLImageKillCliCommandTest.class.st
@@ -30,25 +30,7 @@ PhLImageKillCliCommandTest >> testAllFlag [
 ]
 
 { #category : #test }
-PhLImageKillCliCommandTest >> testOsShellArgArray [
-
-	| killCliCommand  aMatch result|
-	
-	aMatch := (context arguments: #('launcher' 'image' 'kill' 'someImageName')) doMatch.
-	aMatch := (aMatch at: #image) at: #kill.
-	
-	killCliCommand :=  PhLImageKillCliCommand new.
-
-	killCliCommand setArguments: aMatch.
-	result := killCliCommand osShellArgArray.
-	
-	self assert: (result first includesSubstring: 'kill').
-	self assert: (result second includesSubstring: killCliCommand sndKillArgString).
-	
-]
-
-{ #category : #test }
-PhLImageKillCliCommandTest >> testSndKillArgString [
+PhLImageKillCliCommandTest >> testKillArgString [
 
 	| killCliCommand aResult aMatch|
 	
@@ -58,7 +40,7 @@ PhLImageKillCliCommandTest >> testSndKillArgString [
 	killCliCommand setArguments: aMatch.
 	
 		
-	aResult := killCliCommand sndKillArgString.
+	aResult := killCliCommand killArgString.
 	
 	"test if command includes grep of image name"
 	self assert: (aResult includesSubstring: 'grep someImage.image').
@@ -75,10 +57,28 @@ PhLImageKillCliCommandTest >> testSndKillArgString [
 	killCliCommand setArguments: aMatch.
 	
 		
-	aResult := killCliCommand sndKillArgString.
+	aResult := killCliCommand killArgString.
 	"grep of image name shound not be included anymore"
 	self deny: (aResult includesSubstring: 'grep someImage.image').
 
 	"test whether current PID of vm is filtered from list"
 	self assert: (aResult includesSubstring: ('grep -v ', (killCliCommand currentVMPid asString))).
+]
+
+{ #category : #test }
+PhLImageKillCliCommandTest >> testOsShellArgArray [
+
+	| killCliCommand  aMatch result|
+	
+	aMatch := (context arguments: #('launcher' 'image' 'kill' 'someImageName')) doMatch.
+	aMatch := (aMatch at: #image) at: #kill.
+	
+	killCliCommand :=  PhLImageKillCliCommand new.
+
+	killCliCommand setArguments: aMatch.
+	result := killCliCommand osShellArgArray.
+	
+	self assert: (result first includesSubstring: 'kill').
+	self assert: (result second includesSubstring: killCliCommand killArgString).
+	
 ]

--- a/src/PharoLauncher-CLI-Tests/PhLImageKillCliCommandTest.class.st
+++ b/src/PharoLauncher-CLI-Tests/PhLImageKillCliCommandTest.class.st
@@ -7,16 +7,58 @@ Class {
 	#category : #'PharoLauncher-CLI-Tests'
 }
 
-{ #category : #tests }
-PhLImageKillCliCommandTest >> testKillImageCmdStringFrom [
-	| killCliCommand aResult |
-	killCliCommand := PhLImageKillCliCommand new.
+{ #category : #test }
+PhLImageKillCliCommandTest >> testAllFlag [
+
+	| killCliCommand  aMatch aMatch2|
 	
-	"test if not raise exceptions with various input parameters"
-	killCliCommand killImageCmdStringFrom: ''.
-	killCliCommand killImageCmdStringFrom: nil.
+	aMatch := (context arguments: #('launcher' 'image' 'kill' '--all')) doMatch.
+	aMatch := (aMatch at: #image) at: #kill.
 	
-	aResult := killCliCommand killImageCmdStringFrom: 'someImage.image'.
+	aMatch2 := (context arguments: #('launcher' 'image' 'kill' 'someImageName')) doMatch.
+	aMatch2 := (aMatch2 at: #image) at: #kill.
+	
+	killCliCommand :=  PhLImageKillCliCommand new.
+
+	killCliCommand setArguments: aMatch.
+	self assert: killCliCommand allFlag.
+
+	killCliCommand setArguments: aMatch2.
+	self deny: killCliCommand allFlag.
+	
+
+]
+
+{ #category : #test }
+PhLImageKillCliCommandTest >> testOsShellArgArray [
+
+	| killCliCommand  aMatch result|
+	
+	aMatch := (context arguments: #('launcher' 'image' 'kill' 'someImageName')) doMatch.
+	aMatch := (aMatch at: #image) at: #kill.
+	
+	killCliCommand :=  PhLImageKillCliCommand new.
+
+	killCliCommand setArguments: aMatch.
+	result := killCliCommand osShellArgArray.
+	
+	self assert: (result first includesSubstring: 'kill').
+	self assert: (result second includesSubstring: killCliCommand sndKillArgString).
+	
+]
+
+{ #category : #test }
+PhLImageKillCliCommandTest >> testSndKillArgString [
+
+	| killCliCommand aResult aMatch|
+	
+	killCliCommand :=  PhLImageKillCliCommand new.
+	aMatch := (context arguments: #('launcher' 'image' 'kill' 'someImage.image')) doMatch.
+	aMatch := (aMatch at: #image) at: #kill.
+	killCliCommand setArguments: aMatch.
+	
+		
+	aResult := killCliCommand sndKillArgString.
 	
 	"test if command includes grep of image name"
 	self assert: (aResult includesSubstring: 'grep someImage.image').
@@ -26,4 +68,17 @@ PhLImageKillCliCommandTest >> testKillImageCmdStringFrom [
 	
 	"avoid doubling pipes in cascading"
 	self deny: (aResult includesSubstring: '||').
+	
+	"test same method with --all argument present"
+	aMatch := (context arguments: #('launcher' 'image' 'kill' '--all')) doMatch.
+	aMatch := (aMatch at: #image) at: #kill.
+	killCliCommand setArguments: aMatch.
+	
+		
+	aResult := killCliCommand sndKillArgString.
+	"grep of image name shound not be included anymore"
+	self deny: (aResult includesSubstring: 'grep someImage.image').
+
+	"test whether current PID of vm is filtered from list"
+	self assert: (aResult includesSubstring: ('grep -v ', (killCliCommand currentVMPid asString))).
 ]

--- a/src/PharoLauncher-CLI-Tests/PhLImageLaunchCliCommandTest.class.st
+++ b/src/PharoLauncher-CLI-Tests/PhLImageLaunchCliCommandTest.class.st
@@ -112,7 +112,7 @@ PhLImageLaunchCliCommandTest >> testLaunchImageWrongImageName [
 	
 	self runCommand: #('launcher' 'image' 'launch' 'wrongImageName').
 	 
-	self assert: (self errorString includesSubstring: 'please enter a correct local image').
+	self assert: (self errorString includesSubstring: 'Please enter a correct local image.').
 	self deny: image isLaunched. 
 
 	

--- a/src/PharoLauncher-CLI-Tests/PhLImageProcessListCliCommandTest.class.st
+++ b/src/PharoLauncher-CLI-Tests/PhLImageProcessListCliCommandTest.class.st
@@ -19,11 +19,14 @@ PhLImageProcessListCliCommandTest >> testExecute [
 ]
 
 { #category : #test }
-PhLImageProcessListCliCommandTest >> testProcessListCmdString [
+PhLImageProcessListCliCommandTest >> testOsShellArgArray [
 
-	|processListCmd|
+	|processListCmd argArray|
 	processListCmd := PhLImageProcessListCliCommand new.
-	"test whether current PID of vm is filtered from list"
-	self assert: (processListCmd processListCmdString includesSubstring: ('grep -v ', (processListCmd currentVMPid asString))).
+	argArray := processListCmd osShellArgArray.
 	
+	"test whether current PID of vm is filtered from list"
+	
+	self assert: (argArray third includesSubstring: 'pgrep').
+	self assert: (argArray third includesSubstring: ('grep -v ', (processListCmd currentVMPid asString))).
 ]

--- a/src/PharoLauncher-CLI-Tests/PhLProcessWrapperTest.extension.st
+++ b/src/PharoLauncher-CLI-Tests/PhLProcessWrapperTest.extension.st
@@ -1,0 +1,24 @@
+Extension { #name : #PhLProcessWrapperTest }
+
+{ #category : #'*PharoLauncher-CLI-Tests' }
+PhLProcessWrapperTest >> setupProcessCmdWith: aCmdString [
+	^ PhLProcessWrapper new
+		shellCommand;
+		addArguments: aCmdString;
+		yourself
+]
+
+{ #category : #'*PharoLauncher-CLI-Tests' }
+PhLProcessWrapperTest >> testRunAndWaitWithStdOutput [
+
+	"test if command normally returns content of stdout"
+	self deny: (self setupProcessCmdWith: 'ls') runAndWaitWithStdOutput isEmptyOrNil.
+
+	"wrong command raises exception with proper description"
+	[ (self setupProcessCmdWith: 'something') runAndWaitWithStdOutput ]
+		on: PhLProcessCommandError
+		do: [ :ex | 
+			self assert: (ex description includesSubstring: 'OS process command exit with:').
+			self assert: (ex description includesSubstring: 'Stderr contents:').
+			self assert: (ex description includesSubstring: 'something') ]
+]

--- a/src/PharoLauncher-CLI-Tests/PhLProcessWrapperTest.extension.st
+++ b/src/PharoLauncher-CLI-Tests/PhLProcessWrapperTest.extension.st
@@ -18,7 +18,7 @@ PhLProcessWrapperTest >> testRunAndWaitWithStdOutput [
 	[ (self setupProcessCmdWith: 'something') runAndWaitWithStdOutput ]
 		on: PhLProcessCommandError
 		do: [ :ex | 
-			self assert: (ex description includesSubstring: 'OS process command exit with:').
+			self assert: (ex description includesSubstring: 'OS process command:').
 			self assert: (ex description includesSubstring: 'Stderr contents:').
 			self assert: (ex description includesSubstring: 'something') ]
 ]

--- a/src/PharoLauncher-CLI-Tests/PhLProcessWrapperTest.extension.st
+++ b/src/PharoLauncher-CLI-Tests/PhLProcessWrapperTest.extension.st
@@ -1,21 +1,33 @@
 Extension { #name : #PhLProcessWrapperTest }
 
 { #category : #'*PharoLauncher-CLI-Tests' }
-PhLProcessWrapperTest >> setupProcessCmdWith: aCmdString [
+PhLProcessWrapperTest >> setupProcessCmdWithArgs: argArray [
+
 	^ PhLProcessWrapper new
 		shellCommand;
-		addArguments: aCmdString;
+		addAllArguments: argArray;
 		yourself
+]
+
+{ #category : #'*PharoLauncher-CLI-Tests' }
+PhLProcessWrapperTest >> testAddAllArguments [
+
+	|aWrapper|
+	aWrapper := PhLProcessWrapper new.
+	aWrapper addAllArguments: #('a' 'b').
+	self assert: aWrapper arguments size equals: 2.
+	self assert: aWrapper arguments first equals: 'a'.
+	self assert: aWrapper arguments second equals: 'b'.
 ]
 
 { #category : #'*PharoLauncher-CLI-Tests' }
 PhLProcessWrapperTest >> testRunAndWaitWithStdOutput [
 
 	"test if command normally returns content of stdout"
-	self deny: (self setupProcessCmdWith: 'ls') runAndWaitWithStdOutput isEmptyOrNil.
+	self deny: (self setupProcessCmdWithArgs: #('ls')) runAndWaitWithStdOutput isEmptyOrNil.
 
 	"wrong command raises exception with proper description"
-	[ (self setupProcessCmdWith: 'something') runAndWaitWithStdOutput ]
+	[ (self setupProcessCmdWithArgs: #('something')) runAndWaitWithStdOutput ]
 		on: PhLProcessCommandError
 		do: [ :ex | 
 			self assert: (ex description includesSubstring: 'OS process command:').

--- a/src/PharoLauncher-CLI/ConsoleProgressBar.class.st
+++ b/src/PharoLauncher-CLI/ConsoleProgressBar.class.st
@@ -9,7 +9,7 @@ Class {
 		'value',
 		'outStream'
 	],
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Utility'
 }
 
 { #category : #'instance creation' }

--- a/src/PharoLauncher-CLI/OSSUnixSubprocess.extension.st
+++ b/src/PharoLauncher-CLI/OSSUnixSubprocess.extension.st
@@ -1,0 +1,38 @@
+Extension { #name : #OSSUnixSubprocess }
+
+{ #category : #'*PharoLauncher-CLI' }
+OSSUnixSubprocess >> argumentsString [
+
+	^ Character space join: self argVArguments allButLast
+]
+
+{ #category : #'*PharoLauncher-CLI' }
+OSSUnixSubprocess >> getExceptionMessageFor: cmdString status: statusMsg stdError: errorString [
+
+	^ String streamContents: [:aStream | 
+		aStream 
+			nextPutAll: ('OS process command: ''{1}''  exited with: {2}.' format: {cmdString. statusMsg.});
+			nextPutAll: OSPlatform current lineEnding;
+			nextPutAll: ('Stderr contents: "{1}".' format: {errorString}).
+	]
+]
+
+{ #category : #'*PharoLauncher-CLI' }
+OSSUnixSubprocess >> runAndWaitWithStdOutput [
+	"this is helper method to catch std. output and return to sender of this method, 
+	 exit codes are handled and proper exception is raised, when not successful
+	"
+
+	self 
+		redirectStdout;
+		redirectStderr;
+		runAndWaitOnExitDo: [ :termProcess :outString :errString | 
+			termProcess isSuccess
+				ifTrue: [ ^ outString ]
+				ifFalse: [ | exceptionMessage |
+					exceptionMessage := self
+						getExceptionMessageFor: self argumentsString
+						status: termProcess exitStatusInterpreter printString
+						stdError: errString.
+					PhLProcessCommandError signal: exceptionMessage ] ]
+]

--- a/src/PharoLauncher-CLI/OSWSWinProcess.extension.st
+++ b/src/PharoLauncher-CLI/OSWSWinProcess.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #OSWSWinProcess }
+
+{ #category : #'*PharoLauncher-CLI' }
+OSWSWinProcess >> runAndWaitWithStdOutput [
+	"this is dummy implementation, TODO: handle std ourput, err output on windows"
+
+	self runAndWait.
+	^ ''
+]

--- a/src/PharoLauncher-CLI/PhLCliClapContext.class.st
+++ b/src/PharoLauncher-CLI/PhLCliClapContext.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'launcherModel'
 	],
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Model'
 }
 
 { #category : #initialization }

--- a/src/PharoLauncher-CLI/PhLCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLCliCommand.class.st
@@ -118,13 +118,18 @@ PhLCliCommand >> execute [
 ]
 
 { #category : #'command execution' }
-PhLCliCommand >> executeOSShellCommand: cmdString [
+PhLCliCommand >> executeOSShellCommand [
 
- ^ PhLProcessWrapper new 
+	^ self executeOSShellCommandWithArgs: self osShellArgArray
+]
+
+{ #category : #'command execution' }
+PhLCliCommand >> executeOSShellCommandWithArgs: argArray [
+
+^ PhLProcessWrapper new 
 		shellCommand;
-		addArguments: cmdString;
+		addAllArguments: argArray;
 		runAndWaitWithStdOutput
-	
 ]
 
 { #category : #querying }
@@ -163,6 +168,12 @@ PhLCliCommand >> messageErrorCategoryNotFound [
 	self errorStream nextPutAll: 'please enter a correct category '.
 	self errorStream newLine.
 	^ self
+]
+
+{ #category : #'command execution' }
+PhLCliCommand >> osShellArgArray [
+	"No OS shell arguments by default, using array instead of string"
+	^ #()
 ]
 
 { #category : #'private ' }

--- a/src/PharoLauncher-CLI/PhLCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLCliCommand.class.st
@@ -117,6 +117,16 @@ PhLCliCommand >> execute [
 	^ self context exitSuccess
 ]
 
+{ #category : #'command execution' }
+PhLCliCommand >> executeOSShellCommand: cmdString [
+
+ ^ PhLProcessWrapper new 
+		shellCommand;
+		addArguments: cmdString;
+		runAndWaitWithStdOutput
+	
+]
+
 { #category : #querying }
 PhLCliCommand >> findLatestPharoStableVersionIn: aLocation [
 	^ (aLocation

--- a/src/PharoLauncher-CLI/PhLCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLCliCommand.class.st
@@ -163,6 +163,13 @@ PhLCliCommand >> listAsSton: aCollection [
 	self outStream nextPutAll: (STON toString: aCollection) 
 ]
 
+{ #category : #printing }
+PhLCliCommand >> logExceptionMessage: errMessage [
+
+	self errorStream nextPutAll: errMessage.
+	self errorStream newLine.
+]
+
 { #category : #message }
 PhLCliCommand >> messageErrorCategoryNotFound [
 	self errorStream nextPutAll: 'please enter a correct category '.

--- a/src/PharoLauncher-CLI/PhLCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLCliCommand.class.st
@@ -18,7 +18,7 @@ Class {
 		'pharoLauncherModel',
 		'errorStream'
 	],
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line - converting' }

--- a/src/PharoLauncher-CLI/PhLImageCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageCliCommand.class.st
@@ -45,16 +45,6 @@ PhLImageCliCommand >> execute [
 		do: [ ^ self logImageNotFoundMessage ]
 ]
 
-{ #category : #'command execution' }
-PhLImageCliCommand >> executeOSShellCommand: cmdString [
-
- ^ PhLProcessWrapper new 
-		shellCommand;
-		addArguments: cmdString;
-		runAndWaitWithStdOutput
-	
-]
-
 { #category : #'find-select' }
 PhLImageCliCommand >> findByPath: anImageName [
 	(anImageName asFileReference exists

--- a/src/PharoLauncher-CLI/PhLImageCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageCliCommand.class.st
@@ -13,7 +13,7 @@ I execute:
 Class {
 	#name : #PhLImageCliCommand,
 	#superclass : #PhLCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line' }
@@ -43,6 +43,16 @@ PhLImageCliCommand >> execute [
 	[ self executeWithImage: self findImage ]
 		on: NotFound
 		do: [ ^ self logImageNotFoundMessage ]
+]
+
+{ #category : #'command execution' }
+PhLImageCliCommand >> executeOSShellCommand: cmdString [
+
+ ^ PhLProcessWrapper new 
+		shellCommand;
+		addArguments: cmdString;
+		runAndWaitWithStdOutput
+	
 ]
 
 { #category : #'find-select' }

--- a/src/PharoLauncher-CLI/PhLImageCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageCliCommand.class.st
@@ -23,7 +23,7 @@ PhLImageCliCommand class >> asCliCommand [
 
 { #category : #'as yet unclassified' }
 PhLImageCliCommand class >> imageNotFoundMessage [
-	^ 'please enter a correct local image'
+	^ 'Please enter a correct local image.'
 ]
 
 { #category : #'command line' }
@@ -42,7 +42,7 @@ PhLImageCliCommand class >> launcherCmdSubcommands [
 PhLImageCliCommand >> execute [
 	[ self executeWithImage: self findImage ]
 		on: NotFound
-		do: [ ^ self logImageNotFoundMessage ]
+		do: [:ex | ^ self logExceptionMessage: ex printString ]
 ]
 
 { #category : #'find-select' }

--- a/src/PharoLauncher-CLI/PhLImageCopyCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageCopyCliCommand.class.st
@@ -15,7 +15,7 @@ Example of utilisation with imageToCopy and copiedImageName:
 Class {
 	#name : #PhLImageCopyCliCommand,
 	#superclass : #PhLImageCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line' }

--- a/src/PharoLauncher-CLI/PhLImageCopyCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageCopyCliCommand.class.st
@@ -58,5 +58,5 @@ PhLImageCopyCliCommand >> executeWithImage: anImage [
 
 { #category : #accessing }
 PhLImageCopyCliCommand >> targetName [
-	^ (arguments at: #newImageName) word
+	^ (arguments at: #newImageName) value
 ]

--- a/src/PharoLauncher-CLI/PhLImageCopyCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageCopyCliCommand.class.st
@@ -36,19 +36,20 @@ PhLImageCopyCliCommand class >> launcherCmdPositionals [
 				description: 'Local image name to be copied.';
 					meaning: [ :pos | pos  asString ];
 					implicitMeaning: [ :arg :app |NotFound 
-        signal: 'image to copy argument is missing' . ];
+        signal: 'Image to copy argument is missing.' . ];
 					yourself).
 		((ClapPositional id: #newImageName)
 				description: 'New image name of a copied image.';
 					meaning: [ :pos | pos  asString ];
 					implicitMeaning: [ :arg :app |NotFound 
-        signal: 'new image name argument is missing' .   ];
+        signal: 'New image name argument is missing.' .   ];
 					yourself)	
 	}
 ]
 
 { #category : #'command execution' }
 PhLImageCopyCliCommand >> executeWithImage: anImage [
+
 	[ self imageRepository copyImage: anImage to: self targetName ]
 		on: PhLNameNotAvailableError
 		do: [ ^ self errorStream
@@ -58,5 +59,8 @@ PhLImageCopyCliCommand >> executeWithImage: anImage [
 
 { #category : #accessing }
 PhLImageCopyCliCommand >> targetName [
-	^ (arguments at: #newImageName) value
+
+^ (arguments at: #newImageName)
+		value: self;
+		word
 ]

--- a/src/PharoLauncher-CLI/PhLImageCreateCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageCreateCliCommand.class.st
@@ -28,7 +28,7 @@ Open your terminal in the directory containing the pharo executable. You need to
 Class {
 	#name : #PhLImageCreateCliCommand,
 	#superclass : #PhLImageCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line' }

--- a/src/PharoLauncher-CLI/PhLImageCreateFromBuildCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageCreateFromBuildCliCommand.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'template'
 	],
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line' }

--- a/src/PharoLauncher-CLI/PhLImageDeleteCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageDeleteCliCommand.class.st
@@ -10,7 +10,7 @@ I execute:
 Class {
 	#name : #PhLImageDeleteCliCommand,
 	#superclass : #PhLImageCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line' }

--- a/src/PharoLauncher-CLI/PhLImageInfoCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageInfoCliCommand.class.st
@@ -11,7 +11,7 @@ I execute:
 Class {
 	#name : #PhLImageInfoCliCommand,
 	#superclass : #PhLImageCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line' }

--- a/src/PharoLauncher-CLI/PhLImageKillCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageKillCliCommand.class.st
@@ -52,7 +52,7 @@ PhLImageKillCliCommand >> execute [
 { #category : #commands }
 PhLImageKillCliCommand >> killAllImages [
 	
-	^ LibC runCommand: (self killImageCmdStringFrom: nil)
+	^ self executeOSShellCommand: (self killImageCmdStringFrom: nil)
 ]
 
 { #category : #commands }
@@ -71,5 +71,5 @@ PhLImageKillCliCommand >> killImageCmdStringFrom: anImageName [
 { #category : #commands }
 PhLImageKillCliCommand >> killSelectedImage [
 
-	^ LibC runCommand: (self killImageCmdStringFrom: self imageName)
+	^ self executeOSShellCommand: (self killImageCmdStringFrom: self imageName)
 ]

--- a/src/PharoLauncher-CLI/PhLImageKillCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageKillCliCommand.class.st
@@ -51,11 +51,24 @@ PhLImageKillCliCommand >> execute [
 
 ]
 
+{ #category : #commands }
+PhLImageKillCliCommand >> killArgString [
+
+	^ String
+		streamContents: [ :aStream | 
+			aStream nextPutAll: '$(pgrep -a -f Pharo | grep -v ';
+			nextPutAll: self currentVMPid asString.
+			self allFlag ifFalse: [ aStream
+						nextPutAll: ' | grep ';
+						nextPutAll:  self imageName ].
+			aStream nextPutAll: ' | tr -s '' '' | cut -d '' '' -f1)>' ]
+]
+
 { #category : #'command execution' }
 PhLImageKillCliCommand >> osShellArgArray [
 
 	"provide list of command and its args in array"
-	^ Array with: 'kill' with: self sndKillArgString with: '/dev/null'
+	^ Array with: 'kill' with: self killArgString with: '/dev/null'
 ]
 
 { #category : #commands }

--- a/src/PharoLauncher-CLI/PhLImageKillCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageKillCliCommand.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'allFlag'
 	],
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line' }

--- a/src/PharoLauncher-CLI/PhLImageKillCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageKillCliCommand.class.st
@@ -4,9 +4,6 @@ Command to kill one image if given in option or all the images if the --all flag
 Class {
 	#name : #PhLImageKillCliCommand,
 	#superclass : #PhLImageCliCommand,
-	#instVars : [
-		'allFlag'
-	],
 	#category : #'PharoLauncher-CLI-Commands'
 }
 
@@ -41,35 +38,35 @@ PhLImageKillCliCommand class >> launcherCmdPositionals [
 	}
 ]
 
+{ #category : #accessing }
+PhLImageKillCliCommand >> allFlag [
+
+	^ (arguments at: #all) value
+]
+
 { #category : #'command execution' }
 PhLImageKillCliCommand >> execute [
-	(arguments at: #all) value
-		ifTrue: [ ^ (self killAllImages) ].
-	^ self killSelectedImage 
-
-]
-
-{ #category : #commands }
-PhLImageKillCliCommand >> killAllImages [
 	
-	^ self executeOSShellCommand: (self killImageCmdStringFrom: nil)
+	^ self executeOSShellCommand 
+
+]
+
+{ #category : #'command execution' }
+PhLImageKillCliCommand >> osShellArgArray [
+
+	"provide list of command and its args in array"
+	^ Array with: 'kill' with: self sndKillArgString with: '/dev/null'
 ]
 
 { #category : #commands }
-PhLImageKillCliCommand >> killImageCmdStringFrom: anImageName [
+PhLImageKillCliCommand >> sndKillArgString [
+
 	^ String
 		streamContents: [ :aStream | 
-			aStream nextPutAll: 'kill $(pgrep -a -f Pharo | grep -v ';
+			aStream nextPutAll: '$(pgrep -a -f Pharo | grep -v ';
 			nextPutAll: self currentVMPid asString.
-			anImageName isEmptyOrNil
-				ifFalse: [ aStream
+			self allFlag ifFalse: [ aStream
 						nextPutAll: ' | grep ';
-						nextPutAll: anImageName ].
-			aStream nextPutAll: ' | tr -s '' '' | cut -d '' '' -f1)> /dev/null' ]
-]
-
-{ #category : #commands }
-PhLImageKillCliCommand >> killSelectedImage [
-
-	^ self executeOSShellCommand: (self killImageCmdStringFrom: self imageName)
+						nextPutAll:  self imageName ].
+			aStream nextPutAll: ' | tr -s '' '' | cut -d '' '' -f1)>' ]
 ]

--- a/src/PharoLauncher-CLI/PhLImageLaunchCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageLaunchCliCommand.class.st
@@ -13,7 +13,7 @@ Class {
 	#instVars : [
 		'useScript'
 	],
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line' }

--- a/src/PharoLauncher-CLI/PhLImageListCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageListCliCommand.class.st
@@ -10,7 +10,7 @@ I execute:
 Class {
 	#name : #PhLImageListCliCommand,
 	#superclass : #PhLImageCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line' }

--- a/src/PharoLauncher-CLI/PhLImagePackageCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImagePackageCliCommand.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'image'
 	],
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line' }

--- a/src/PharoLauncher-CLI/PhLImageProcessListCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageProcessListCliCommand.class.st
@@ -23,17 +23,13 @@ PhLImageProcessListCliCommand >> execute [
 	"TODO rewrite this to more meaningful output with columns like PID, datetime started, vm name, image name"
 	
 	self outStream 
-		nextPutAll: (self executeOSShellCommand: self processListCmdString).
+		nextPutAll: self executeOSShellCommand.
 	^ self context exitSuccess 
 ]
 
 { #category : #'command execution' }
-PhLImageProcessListCliCommand >> processListCmdString [
+PhLImageProcessListCliCommand >> osShellArgArray [ 
 
-	^ String streamContents: [ :aStream |		
-		aStream 
-			nextPutAll: 'echo -n $(pgrep -a -f Pharo | grep ''.image'' | grep -v ''.bash''| grep -v ';
-			nextPutAll: self currentVMPid asString;
-			nextPutAll: ')'.
-	]
+	^ Array with: 'echo' with: '-n' with: ('$(pgrep -a -f Pharo | grep ''.image'' | grep -v ''.bash''| grep -v {1})' format: {self currentVMPid asString})
+
 ]

--- a/src/PharoLauncher-CLI/PhLImageProcessListCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageProcessListCliCommand.class.st
@@ -19,14 +19,11 @@ PhLImageProcessListCliCommand class >> launcherCmdDescription [
 
 { #category : #'command execution' }
 PhLImageProcessListCliCommand >> execute [
-	"The brackets between the P of Pharo is to avoid to list the get procress when using ps x."
-	"The grep -v ps is to avoid to list the pharo launcher image."
 	
-	"TODO rewrite use to OSSubProcess since execution can check exit code and result of bash command at once, libc can do just one or another"
 	"TODO rewrite this to more meaningful output with columns like PID, datetime started, vm name, image name"
 	
 	self outStream 
-		nextPutAll: (LibC resultOfCommand: self processListCmdString).
+		nextPutAll: (self executeOSShellCommand: self processListCmdString).
 	^ self context exitSuccess 
 ]
 

--- a/src/PharoLauncher-CLI/PhLImageProcessListCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageProcessListCliCommand.class.st
@@ -32,7 +32,8 @@ PhLImageProcessListCliCommand >> processListCmdString [
 
 	^ String streamContents: [ :aStream |		
 		aStream 
-			nextPutAll: 'pgrep -a -f Pharo | grep ''.image'' | grep -v ''.bash''| grep -v ';
-			nextPutAll: self currentVMPid asString.
+			nextPutAll: 'echo -n $(pgrep -a -f Pharo | grep ''.image'' | grep -v ''.bash''| grep -v ';
+			nextPutAll: self currentVMPid asString;
+			nextPutAll: ')'.
 	]
 ]

--- a/src/PharoLauncher-CLI/PhLImageProcessListCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageProcessListCliCommand.class.st
@@ -4,7 +4,7 @@ Command to list all the running images.
 Class {
 	#name : #PhLImageProcessListCliCommand,
 	#superclass : #PhLImageCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line' }

--- a/src/PharoLauncher-CLI/PhLImageProcessListCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageProcessListCliCommand.class.st
@@ -32,8 +32,7 @@ PhLImageProcessListCliCommand >> processListCmdString [
 
 	^ String streamContents: [ :aStream |		
 		aStream 
-			nextPutAll: 'bash -c "pgrep -a -f Pharo | grep ''.image'' | grep -v ''.bash''| grep -v ';
-			nextPutAll: self currentVMPid asString;
-			nextPutAll: '"'
+			nextPutAll: 'pgrep -a -f Pharo | grep ''.image'' | grep -v ''.bash''| grep -v ';
+			nextPutAll: self currentVMPid asString.
 	]
 ]

--- a/src/PharoLauncher-CLI/PhLImageRecreateCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLImageRecreateCliCommand.class.st
@@ -4,7 +4,7 @@ Command to reset an image
 Class {
 	#name : #PhLImageRecreateCliCommand,
 	#superclass : #PhLImageCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line' }

--- a/src/PharoLauncher-CLI/PhLInvalidConfiguration.class.st
+++ b/src/PharoLauncher-CLI/PhLInvalidConfiguration.class.st
@@ -4,5 +4,5 @@ Error raised when we read the Pharo launcherCLi configuration is present but not
 Class {
 	#name : #PhLInvalidConfiguration,
 	#superclass : #PhLError,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Exceptions'
 }

--- a/src/PharoLauncher-CLI/PhLNotificationCenter.class.st
+++ b/src/PharoLauncher-CLI/PhLNotificationCenter.class.st
@@ -8,7 +8,7 @@ Class {
 	#classVars : [
 		'Default'
 	],
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Utility'
 }
 
 { #category : #accessing }

--- a/src/PharoLauncher-CLI/PhLProcessCommandError.class.st
+++ b/src/PharoLauncher-CLI/PhLProcessCommandError.class.st
@@ -1,0 +1,8 @@
+"
+Represents Domain error of Pharo Launcher when OS process command (executed from Pharo launcher CLI command) execution fails.
+"
+Class {
+	#name : #PhLProcessCommandError,
+	#superclass : #PhLCommandError,
+	#category : #'PharoLauncher-CLI-Exceptions'
+}

--- a/src/PharoLauncher-CLI/PhLProcessWrapper.extension.st
+++ b/src/PharoLauncher-CLI/PhLProcessWrapper.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #PhLProcessWrapper }
 
 { #category : #'*PharoLauncher-CLI' }
+PhLProcessWrapper >> addAllArguments: argsArray [
+	
+	"supplemental method for adding args from array and not just a string"
+	argsArray do: [:arg | self addArgument: arg ]
+]
+
+{ #category : #'*PharoLauncher-CLI' }
 PhLProcessWrapper >> getExceptionMessageFor: cmdString status: statusMsg stdError: errorString [
 
 	^ String streamContents: [:aStream | 
@@ -18,16 +25,6 @@ PhLProcessWrapper >> runAndWaitWithStdOutput [
 	"
 
 	self prepareProcess.
-	process
-		redirectStdout;
-		redirectStderr;
-		runAndWaitOnExitDo: [ :termProcess :outString :errString | 
-			termProcess isSuccess
-				ifTrue: [ ^ outString ]
-				ifFalse: [ | exceptionMessage |
-					exceptionMessage := self
-						getExceptionMessageFor: self commandLineString
-						status: termProcess exitStatusInterpreter printString
-						stdError: errString.
-					PhLProcessCommandError signal: exceptionMessage ] ]
+	"return content of stdout, may throw exception that can be handled by sender of this method"
+	^ process runAndWaitWithStdOutput 
 ]

--- a/src/PharoLauncher-CLI/PhLProcessWrapper.extension.st
+++ b/src/PharoLauncher-CLI/PhLProcessWrapper.extension.st
@@ -8,17 +8,6 @@ PhLProcessWrapper >> addAllArguments: argsArray [
 ]
 
 { #category : #'*PharoLauncher-CLI' }
-PhLProcessWrapper >> getExceptionMessageFor: cmdString status: statusMsg stdError: errorString [
-
-	^ String streamContents: [:aStream | 
-		aStream 
-			nextPutAll: ('OS process command: ''{1}''  exited with: {2}.' format: {cmdString. statusMsg.});
-			nextPutAll: OSPlatform current lineEnding;
-			nextPutAll: ('Stderr contents: "{1}".' format: {errorString}).
-	]
-]
-
-{ #category : #'*PharoLauncher-CLI' }
 PhLProcessWrapper >> runAndWaitWithStdOutput [
 	"this is helper method to catch std. output and return to sender of this method, 
 	 exit codes are handled and proper exception is raised, when not successful

--- a/src/PharoLauncher-CLI/PhLProcessWrapper.extension.st
+++ b/src/PharoLauncher-CLI/PhLProcessWrapper.extension.st
@@ -1,26 +1,33 @@
 Extension { #name : #PhLProcessWrapper }
 
 { #category : #'*PharoLauncher-CLI' }
+PhLProcessWrapper >> getExceptionMessageFor: cmdString status: statusMsg stdError: errorString [
+
+	^ String streamContents: [:aStream | 
+		aStream 
+			nextPutAll: ('OS process command: ''{1}''  exited with: {2}.' format: {cmdString. statusMsg.});
+			nextPutAll: OSPlatform current lineEnding;
+			nextPutAll: ('Stderr contents: "{1}".' format: {errorString}).
+	]
+]
+
+{ #category : #'*PharoLauncher-CLI' }
 PhLProcessWrapper >> runAndWaitWithStdOutput [
 	"this is helper method to catch std. output and return to sender of this method, 
 	 exit codes are handled and proper exception is raised, when not successful
 	"
+
 	self prepareProcess.
-	process 
+	process
 		redirectStdout;
 		redirectStderr;
-	runAndWaitOnExitDo: [:termProcess :outString :errString |
-		termProcess isSuccess
-			ifTrue: [^ outString ]
-			ifFalse: [
-				|exceptionMessage|
-				exceptionMessage := String streamContents: [:aStream | 
-				aStream nextPutAll: 'OS process command exit with: ';
-				 nextPutAll: termProcess exitStatusInterpreter printString;
-				 nextPutAll: OSPlatform current lineEnding;
-				 nextPutAll: '. Stderr contents: ';
-				 nextPutAll: errString.
-				].
-			PhLProcessCommandError signal: exceptionMessage.
-	]]
+		runAndWaitOnExitDo: [ :termProcess :outString :errString | 
+			termProcess isSuccess
+				ifTrue: [ ^ outString ]
+				ifFalse: [ | exceptionMessage |
+					exceptionMessage := self
+						getExceptionMessageFor: self commandLineString
+						status: termProcess exitStatusInterpreter printString
+						stdError: errString.
+					PhLProcessCommandError signal: exceptionMessage ] ]
 ]

--- a/src/PharoLauncher-CLI/PhLProcessWrapper.extension.st
+++ b/src/PharoLauncher-CLI/PhLProcessWrapper.extension.st
@@ -1,0 +1,26 @@
+Extension { #name : #PhLProcessWrapper }
+
+{ #category : #'*PharoLauncher-CLI' }
+PhLProcessWrapper >> runAndWaitWithStdOutput [
+	"this is helper method to catch std. output and return to sender of this method, 
+	 exit codes are handled and proper exception is raised, when not successful
+	"
+	self prepareProcess.
+	process 
+		redirectStdout;
+		redirectStderr;
+	runAndWaitOnExitDo: [:termProcess :outString :errString |
+		termProcess isSuccess
+			ifTrue: [^ outString ]
+			ifFalse: [
+				|exceptionMessage|
+				exceptionMessage := String streamContents: [:aStream | 
+				aStream nextPutAll: 'OS process command exit with: ';
+				 nextPutAll: termProcess exitStatusInterpreter printString;
+				 nextPutAll: OSPlatform current lineEnding;
+				 nextPutAll: '. Stderr contents: ';
+				 nextPutAll: errString.
+				].
+			PhLProcessCommandError signal: exceptionMessage.
+	]]
+]

--- a/src/PharoLauncher-CLI/PhLTemplateCategoriesCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLTemplateCategoriesCliCommand.class.st
@@ -10,7 +10,7 @@ I execute:
 Class {
 	#name : #PhLTemplateCategoriesCliCommand,
 	#superclass : #PhLTemplateCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line - converting' }

--- a/src/PharoLauncher-CLI/PhLTemplateCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLTemplateCliCommand.class.st
@@ -13,7 +13,7 @@ I execute:
 Class {
 	#name : #PhLTemplateCliCommand,
 	#superclass : #PhLCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line - converting' }

--- a/src/PharoLauncher-CLI/PhLTemplateInfoCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLTemplateInfoCliCommand.class.st
@@ -10,7 +10,7 @@ I execute:
 Class {
 	#name : #PhLTemplateInfoCliCommand,
 	#superclass : #PhLTemplateCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line - converting' }

--- a/src/PharoLauncher-CLI/PhLTemplateListCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLTemplateListCliCommand.class.st
@@ -10,7 +10,7 @@ I execute:
 Class {
 	#name : #PhLTemplateListCliCommand,
 	#superclass : #PhLTemplateCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line - converting' }

--- a/src/PharoLauncher-CLI/PhLVmCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLVmCliCommand.class.st
@@ -12,7 +12,7 @@ I declare:
 Class {
 	#name : #PhLVmCliCommand,
 	#superclass : #PhLCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line - converting' }

--- a/src/PharoLauncher-CLI/PhLVmDeleteCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLVmDeleteCliCommand.class.st
@@ -10,7 +10,7 @@ I execute:
 Class {
 	#name : #PhLVmDeleteCliCommand,
 	#superclass : #PhLVmCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line - converting' }

--- a/src/PharoLauncher-CLI/PhLVmInfoCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLVmInfoCliCommand.class.st
@@ -11,7 +11,7 @@ I execute:
 Class {
 	#name : #PhLVmInfoCliCommand,
 	#superclass : #PhLVmCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line - converting' }

--- a/src/PharoLauncher-CLI/PhLVmListCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLVmListCliCommand.class.st
@@ -10,7 +10,7 @@ I execute:
 Class {
 	#name : #PhLVmListCliCommand,
 	#superclass : #PhLVmCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line - converting' }

--- a/src/PharoLauncher-CLI/PhLVmUpdateCliCommand.class.st
+++ b/src/PharoLauncher-CLI/PhLVmUpdateCliCommand.class.st
@@ -10,7 +10,7 @@ I execute:
 Class {
 	#name : #PhLVmUpdateCliCommand,
 	#superclass : #PhLVmCliCommand,
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Commands'
 }
 
 { #category : #'command line - converting' }

--- a/src/PharoLauncher-CLI/PharoLauncherCLIConfiguration.class.st
+++ b/src/PharoLauncher-CLI/PharoLauncherCLIConfiguration.class.st
@@ -10,7 +10,7 @@ Class {
 		'launchImageFromALoginShell',
 		'initScriptsDirectory'
 	],
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Model'
 }
 
 { #category : #'error signalling' }

--- a/src/PharoLauncher-CLI/PharoLauncherCLIModel.class.st
+++ b/src/PharoLauncher-CLI/PharoLauncherCLIModel.class.st
@@ -9,7 +9,7 @@ Class {
 		'templateRepository',
 		'vmManager'
 	],
-	#category : #'PharoLauncher-CLI'
+	#category : #'PharoLauncher-CLI-Model'
 }
 
 { #category : #accessing }


### PR DESCRIPTION
replaced LibC calls with ProcessWrapper OSSubProcess command checking exit code
- changed kill command and processList command to use process wrapper instead of LibC